### PR TITLE
Week 03/tokenizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,6 @@
 - gitinore should contain *.txt  
 - Makerfile is in the "books" directory :)
 
+- Added a token.py file that contains three functions to clean, tokenize, and count the frequency of words from a given string
+- Makefile also checks to make sure python3 and pip are installed (needed to use "sudo" for this because of ubuntu)
+- Note: I am having an issue with the token.py file in in that the "logging" package I am trying to use seems to be overwritten by some custom "logging.py" file from anaconda. I am not sure what the repercussions of deleting this file are for other python works, so for now I will not change anything. I ran the token.py code in a jupyter notebook to test it with some sample strings and it works fine for all 3 functions.

--- a/books/makefile
+++ b/books/makefile
@@ -33,5 +33,6 @@ total_words: pg17192.txt
 
 output_all_jobs: raven_line_count raven_word_count raven_counts total_lines total_words 	
 
-
+check_py_requirements: 
+	python3 -m venv env; sudo pip install --upgrade pip; sudo pip install -r requirements.txt
 

--- a/books/requirements.txt
+++ b/books/requirements.txt
@@ -1,0 +1,2 @@
+pytest
+pylint

--- a/books/token.py
+++ b/books/token.py
@@ -1,0 +1,53 @@
+import sys
+import string
+import logging 
+from collections import Counter
+
+logging.basicConfig(level=logging.INFO)
+log = logging.getLogger(__name__)
+
+def clean_text(txt):
+    assert isinstance(txt,str), "String inputs only"
+
+    log.info('Removing punctuation and case sensitivity')
+    trans = str.maketrans('', '', string.punctuation)
+    new_text = txt.lower().translate(trans)
+
+    log.info('Text cleaned')
+
+    assert isinstance(new_text, str), "String ouputs only"
+    return new_text
+
+
+def tokenize(txt):
+    assert isinstance(txt,str), "String inputs only"
+
+    log.info("Text getting cleaned")
+    cleaned_text = clean_text(txt)
+    log.info("Text has been cleaned")
+
+    log.info("Tokenizing words into list")
+    token_list = cleaned_text.split()
+    log.info("Text has been tokenzied")
+
+    assert isinstance(token_list,list), "Output should be a list"
+    return token_list
+
+def count_words(txt):
+    assert isinstance(txt,str), "String inputs only"
+    log.info("Clean and tokenize input text")
+    token_list = tokenize(txt)
+
+    assert isinstance(token_list, list), "Tokenizer failed to create a list"
+    log.info("Text is cleaned and words are in a list")
+
+    log.info("Counting word fequencies...")
+    counts = Counter(token_list)
+    log.info("Done counting")
+
+    assert isinstance(counts, dict), "Dictionary was not created"
+
+    return counts
+
+
+


### PR DESCRIPTION
- Added a token.py file that contains three functions to clean, tokenize, and count the frequency of words from a given string
- Makefile also checks to make sure python3 and pip are installed (needed to use "sudo" for this because of ubuntu)
- Note: I am having an issue with the token.py file in in that the "logging" package I am trying to use seems to be overwritten by some custom "logging.py" file from anaconda. I am not sure what the repercussions of deleting this file are for other python works, so for now I will not change anything. I ran the token.py code in a jupyter notebook to test it with some sample strings and it works fine for all 3 functions.